### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: DeterminateSystems/nix-installer-action@v20
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - run: nix flake show --all-systems
       - run: nix flake check --no-build
 
@@ -25,8 +25,8 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: DeterminateSystems/nix-installer-action@v20
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - run: nix fmt -- --fail-on-change
 
   build:
@@ -37,8 +37,8 @@ jobs:
         system: [x86_64-linux, aarch64-linux]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: DeterminateSystems/nix-installer-action@v20
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Build packages
         run: |
           for pkg in $(nix eval --json '#.packages.x86_64-linux' | jq -r 'keys[]'); do


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full commit SHAs instead of mutable version tags.

This prevents supply chain attacks where a compromised tag could silently inject malicious code into CI/CD pipelines (similar to the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).

### Changes

- Replace tag-based references (e.g., `@v4`) with full 40-character commit SHA pins
- Add version comments (e.g., `# v4`) for human readability

### Why

- **Immutability**: Git tags can be force-pushed, but commit SHAs cannot be changed
- **Supply chain security**: Prevents tag hijacking attacks
- **Auditability**: Each pinned version is traceable to an exact commit
